### PR TITLE
Add support for fbp manifest, deep equality checking for output testing

### DIFF
--- a/bin/noflo-test
+++ b/bin/noflo-test
@@ -15,9 +15,15 @@ var args = [
   '--reporter', 'spec',
   '--ui', 'exports'
 ];
-if(process.argv.length === 3) {
-  args.push(process.argv[2]);
+
+// Add extra any extra args provided to node noflo-test
+if(process.argv.length > 2) {
+  for (var i = 2; i < process.argv.length; i++) {
+    args.push(process.argv[i]);
+  }
 }
+
+
 // Execute it
 var runner = childProcess.spawn(mochaBin, args);
 

--- a/bin/noflo-test
+++ b/bin/noflo-test
@@ -9,12 +9,17 @@ var mochaBin = path.resolve(mochaPath, './bin/mocha');
 
 // Allow requiring files without the .js extension
 require.extensions[''] = require.extensions['.js'];
-
-// Execute it
-var runner = childProcess.spawn(mochaBin, [
+console.log(process.argv);
+var args = [
   '--compilers', 'coffee:coffee-script/register',
   '--reporter', 'spec',
-  '--ui', 'exports']);
+  '--ui', 'exports'
+];
+if(process.argv.length === 3) {
+  args.push(process.argv[2]);
+}
+// Execute it
+var runner = childProcess.spawn(mochaBin, args);
 
 runner.stdout.setEncoding('utf8');
 runner.stderr.setEncoding('utf8');

--- a/bin/noflo-test
+++ b/bin/noflo-test
@@ -9,7 +9,7 @@ var mochaBin = path.resolve(mochaPath, './bin/mocha');
 
 // Allow requiring files without the .js extension
 require.extensions[''] = require.extensions['.js'];
-console.log(process.argv);
+
 var args = [
   '--compilers', 'coffee:coffee-script/register',
   '--reporter', 'spec',

--- a/lib/test.coffee
+++ b/lib/test.coffee
@@ -21,7 +21,7 @@ subscribeOutports = (callback, topic, outCommands) ->
       if typeof command.data is 'function'
         command.data result.data, chai
         continue
-      else if Array.isArray(command.data) || typeof command.data === 'object'
+      else if Array.isArray(command.data) || typeof command.data is 'object'
         chai.expect(result.data).to.deep.equal command.data
         continue
       chai.expect(result.data).to.equal command.data

--- a/lib/test.coffee
+++ b/lib/test.coffee
@@ -21,6 +21,9 @@ subscribeOutports = (callback, topic, outCommands) ->
       if typeof command.data is 'function'
         command.data result.data, chai
         continue
+      else if Array.isArray(command.data)
+        chai.expect(result.data).to.deep.equal command.data
+        continue
       chai.expect(result.data).to.equal command.data
     callback null, topic
 

--- a/lib/test.coffee
+++ b/lib/test.coffee
@@ -21,7 +21,7 @@ subscribeOutports = (callback, topic, outCommands) ->
       if typeof command.data is 'function'
         command.data result.data, chai
         continue
-      else if Array.isArray(command.data)
+      else if Array.isArray(command.data) || typeof command.data === 'object'
         chai.expect(result.data).to.deep.equal command.data
         continue
       chai.expect(result.data).to.equal command.data

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "noflo-test",
   "description": "NoFlo component testing library",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "keywords": [
     "gruntplugin",
     "noflo",
@@ -11,7 +11,7 @@
     "mocha": "1.18.2",
     "coffee-script": "1.7.x",
     "underscore": "1.4.x",
-    "noflo": "~0.5.0",
+    "noflo": "0.7.0",
     "chai": "^1.9.1"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "coffee-script": "1.7.x",
     "underscore": "1.4.x",
     "noflo": "~0.7.8",
-    "chai": "^1.9.1"
+    "chai": "^1.9.1",
+    "fbp-manifest": "git://github.com/flowbased/fbp-manifest.git#8e67c1f14fceb15bf2008e18510833025b9ab2a7"
   },
   "devDependencies": {
     "coffeelint": "*",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "mocha": "1.18.2",
     "coffee-script": "1.7.x",
     "underscore": "1.4.x",
-    "noflo": "0.7.0",
+    "noflo": "~0.7.8",
     "chai": "^1.9.1"
   },
   "devDependencies": {


### PR DESCRIPTION
Our noflo project uses the fbp manifest to load our components, which are stored in a fbp friendly structure. We do not use the components property in the package.json method to list our components.

I was able to get noflo-test working with our method of loading components by adding the fbp-manifest to the package.json. I'm not sure if the fbp-manifest version in my package.json should be the one to merge, but I was able to get it working with my version. Guidance on this issue would be much appreciated.

Lastly, I noticed that testing data from an outport does not work for complex types like arrays and objects. I added a case to do deep equality checking with chai that solves this issue as well. I'd love to get this merged back into master on the main repo, and to know how to move forward with that. Thanks!
